### PR TITLE
Removing necessity of importing React in every component

### DIFF
--- a/client/.babelrc
+++ b/client/.babelrc
@@ -1,3 +1,7 @@
 {
-    "presets": ["@babel/preset-env", "@babel/preset-typescript", "@babel/preset-react"] 
+    "presets": [
+        "@babel/preset-env", 
+        "@babel/preset-typescript", 
+        ["@babel/preset-react", {"runtime": "automatic"}]
+    ]
 }

--- a/client/.eslintrc.json
+++ b/client/.eslintrc.json
@@ -12,7 +12,8 @@
 		{
 			"files": ["*.jsx", "*.tsx"],
 			"rules": {
-				"@typescript-eslint/explicit-function-return-type": ["off"]
+				"@typescript-eslint/explicit-function-return-type": ["off"],
+				"react/react-in-jsx-scope": "off"
 			}
 		}
 	],

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import GlobalStyle from './GlobalStyles';
 
 const App = () => {

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "es2016",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
-    "jsx": "react",                                      /* Specify what JSX code is generated. "React" will produce a .js code */
+    "jsx": "react-jsx",                                  /* Specify what JSX code is generated. "React-JSX" will produce a .js code with the "React." being replaced by "_jsx.", which will be a global React we'll insert via babel (this way, we don't need to import React everywhere) */
     "module": "es6",                                     /* Specify what module code is generated. */
     "moduleResolution": "node",                          /* Process the compiler uses to figure it out what an import refers to */
     "allowSyntheticDefaultImports": true,                /* Allow 'import x from y' when a module doesn't have a default export. */


### PR DESCRIPTION
## 🤔 Objective
Removing the necessity of importing React in every component

## 😆 Changes

- Changing babel configuration;
- Turning off eslint's react-in-jsx-scope;
- Changing `tsconfig.json` jsx property to `react-jsx`(so we can avoid importing react, as [said here](https://stackoverflow.com/questions/67776707/ts-config-jsx-reactjsx-vs-react))

## 😫 Caveats
No caveats
  
## ℹ️ Learn More
To fix this, I followed [this recommendation](https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html#how-to-upgrade-to-the-new-jsx-transform) from React team.

